### PR TITLE
Fix reminder service tests

### DIFF
--- a/app/db/models.py
+++ b/app/db/models.py
@@ -1,4 +1,4 @@
 # Импорт моделей для Alembic
 from app.core.users.models import User, Message
-from app.core.achievements.models import Achievement, AchievementRule
+from app.core.achievements.models import Achievement
 from app.core.reminders.models import Reminder

--- a/tests/test_reminders_service.py
+++ b/tests/test_reminders_service.py
@@ -1,17 +1,72 @@
-from app.core.reminders.service import RemindersService
+import os
+import sys
 import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+from datetime import datetime, timedelta
 
-@pytest.fixture(scope='function')
-def svc_and_cleanup():
-    svc = RemindersService()
-    # чистим таблицу
-    svc.db.query(svc.db.get_bind().table_names()).delete()
-    svc.db.commit()
-    yield svc
+# Ensure environment and path setup like other tests
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret")
+import app.conftest  # noqa: F401
 
-def test_reminders_record_and_exists(svc_and_cleanup):
-    svc = svc_and_cleanup
-    user, evt = 'u1','e1'
-    assert not svc.exists(user, evt)
-    svc.record(user, evt)
-    assert svc.exists(user, evt)
+from app.core.reminders.service import RemindersService
+from app.db.base import async_session_context, create_db_and_tables, drop_db_and_tables
+
+
+@pytest_asyncio.fixture(scope="function", autouse=True)
+async def setup_db():
+    await create_db_and_tables()
+    yield
+    await drop_db_and_tables()
+
+
+@pytest_asyncio.fixture
+async def db_session() -> AsyncSession:
+    async with async_session_context() as session:
+        yield session
+
+
+@pytest.mark.asyncio
+async def test_create_and_list_due(db_session: AsyncSession):
+    service = RemindersService(db_session)
+    due_time = datetime.utcnow() - timedelta(minutes=1)
+
+    reminder = await service.create_reminder("u1", "test", due_time)
+    await db_session.commit()
+
+    due = await service.list_due_and_unsent()
+    assert any(r.id == reminder.id for r in due)
+
+
+@pytest.mark.asyncio
+async def test_mark_sent_excludes_from_due_list(db_session: AsyncSession):
+    service = RemindersService(db_session)
+    due_time = datetime.utcnow() - timedelta(minutes=1)
+
+    reminder = await service.create_reminder("u1", "test", due_time)
+    await db_session.commit()
+
+    await service.mark_sent(reminder.id)
+    await db_session.commit()
+
+    due_after = await service.list_due_and_unsent()
+    assert all(r.id != reminder.id for r in due_after)
+
+    updated = await service.get_reminder_by_id(reminder.id)
+    assert updated.sent is True
+
+
+@pytest.mark.asyncio
+async def test_delete_reminder(db_session: AsyncSession):
+    service = RemindersService(db_session)
+    due_time = datetime.utcnow() + timedelta(minutes=5)
+    reminder = await service.create_reminder("u2", "del", due_time)
+    await db_session.commit()
+
+    removed = await service.delete_reminder(reminder.id)
+    await db_session.commit()
+    assert removed is True
+
+    fetched = await service.get_reminder_by_id(reminder.id)
+    assert fetched is None


### PR DESCRIPTION
## Summary
- add async fixtures and real reminder interactions in tests
- support table creation helpers in db layer
- simplify db model imports for alembic

## Testing
- `pytest tests/test_reminders_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6842cefd9b6c832e8298634a68cb0257