### PR TITLE
Refactor achievements tests

### DIFF
--- a/app/db/base.py
+++ b/app/db/base.py
@@ -118,8 +118,33 @@ async def async_session_context() -> AsyncGenerator[AsyncSession, None]:
         await session.close()
 
 
+# --- Helpers for tests -------------------------------------------------
+async def create_db_and_tables() -> None:
+    """Create all tables defined by ``Base``."""
+    if settings.ENVIRONMENT == "test":
+        Base.metadata.create_all(bind=engine)
+    else:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+
+async def drop_db_and_tables() -> None:
+    """Drop all tables defined by ``Base``."""
+    if settings.ENVIRONMENT == "test":
+        Base.metadata.drop_all(bind=engine)
+    else:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+
+
 # --- Экспорты ---
 __all__ = [
-    "Base", "engine", "async_session_factory", "AsyncSession",
-    "get_async_db_session", "async_session_context",
+    "Base",
+    "engine",
+    "async_session_factory",
+    "AsyncSession",
+    "get_async_db_session",
+    "async_session_context",
+    "create_db_and_tables",
+    "drop_db_and_tables",
 ]

--- a/tests/test_achievements_api.py
+++ b/tests/test_achievements_api.py
@@ -1,34 +1,53 @@
-from fastapi.testclient import TestClient
-from app.main import app
-from app.core.achievements.models import AchievementRule, Achievement
-from app.db.base import SessionLocal, Base, engine
 import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from app.main import app
+from app.db.base import create_db_and_tables, drop_db_and_tables, async_session_context
+from app.core.users.models import User
+from app.core.achievements.models import Achievement
+from app.core.auth.security import get_current_user, oauth2_scheme
 
 client = TestClient(app)
 
-@pytest.fixture(scope='function', autouse=True)
-def reset_db():
-    # Очистить и пересоздать схему
-    Base.metadata.drop_all(bind=engine)
-    Base.metadata.create_all(bind=engine)
-    # Добавить правило для теста
-    db = SessionLocal()
-    rule = AchievementRule(code='first_event', title='First', icon_url='url', description='')
-    db.add(rule);
-    db.commit()
+@pytest.fixture(scope="function", autouse=True)
+async def setup_db():
+    await create_db_and_tables()
+    async with async_session_context() as session:
+        session.add(User(id="u1"))
     yield
+    await drop_db_and_tables()
+
+@pytest.fixture(autouse=True)
+def override_auth():
+    async def fake_user():
+        async with async_session_context() as session:
+            return await session.get(User, "u1")
+    app.dependency_overrides[get_current_user] = fake_user
+    app.dependency_overrides[oauth2_scheme] = lambda: "token"
+    yield
+    app.dependency_overrides.clear()
 
 def test_achievements_empty():
-    res = client.get('/v1/achievements/u1')
+    res = client.get("/v1/achievements/me")
     assert res.status_code == 200
     assert res.json() == []
 
-def test_achievements_after_event(monkeypatch):
-    # Мокаем extract_events, возвращаем list
+@pytest.mark.asyncio
+async def test_achievements_after_message(monkeypatch):
     from app.core.llm.client import LLMClient
-    monkeypatch.setattr(LLMClient, 'extract_events', lambda self, txt: [None])
-    # Отправляем chat, чтобы создать медаль
-    res = client.post('/v1/chat/', json={'user_id':'u1','message_text':'hi'})
+    monkeypatch.setattr(LLMClient, "extract_events", lambda self, txt: [None])
+    monkeypatch.setattr(LLMClient, "generate", lambda self, prompt, ctx: "ok")
+
+    chat_res = client.post("/v1/chat/", json={"message_text": "hi"})
+    assert chat_res.status_code == 200
+
+    # achievements are created in PENDING state, so /me still returns empty
+    res = client.get("/v1/achievements/me")
     assert res.status_code == 200
-    ach = client.get('/v1/achievements/u1').json()
-    assert any(a['code']=='first_event' for a in ach)
+    assert res.json() == []
+
+    # verify pending achievement exists in DB
+    async with async_session_context() as session:
+        achs = (await session.execute(select(Achievement))).scalars().all()
+        assert any(a.code == "first_message_sent" for a in achs)


### PR DESCRIPTION
## Summary
- add helpers for async test DB setup
- update achievements API tests for new service

## Testing
- `pytest -q tests/test_achievements_api.py -k none` *(fails: basicConfig() takes 0 positional arguments but 1 was given)*
- `pytest -q` *(fails: basicConfig() takes 0 positional arguments but 1 was given)*

------
https://chatgpt.com/codex/tasks/task_e_684483a808f4832ea197b90f0da8db97