### PR TITLE
Enable routers for audio and calendar

### DIFF
--- a/app/conftest.py
+++ b/app/conftest.py
@@ -8,6 +8,7 @@ sys.path.insert(0, str(os.path.dirname(__file__)))
 # Тестовое окружение: in-memory SQLite и eager Celery
 os.environ.setdefault("ENVIRONMENT", "test")
 os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("JWT_SECRET_KEY", "secret")
 
 # Обязательно после установки ENVIRONMENT подключаем Celery-конфиг eager
 from app.workers.tasks import celery_app

--- a/app/main.py
+++ b/app/main.py
@@ -1,41 +1,28 @@
-# /app/main.py (Добавляем роутер ачивок)
-
 from __future__ import annotations
 import logging
-from fastapi import FastAPI, status
 
-# --- Импорты Роутеров ---
+from fastapi import FastAPI
+
 from app.api.v1.auth import router as auth_router
 from app.api.v1.chat import router as chat_router
-# from app.api.v1.calendar import router as cal_router # Отложен для MVP
-# from app.api.v1.audio import router as audio_router # Отложен для MVP
+from app.api.v1.calendar import router as cal_router
+from app.api.v1.audio import router as audio_router
 from app.api.v1.health import router as health_router
-from app.api.v1.achievements_api import router as achievements_router # <--- НОВЫЙ ИМПОРТ
-# ------------------------
-from app.config import settings
+from app.api.v1.achievements_api import router as achievements_router
 
-logging.basicConfig(...) # Оставляем как есть
-description = """...""" # Оставляем как есть
-tags_metadata = [ # Добавляем тег для ачивок
-    {"name": "Authentication & Testing", "description": "..."},
-    {"name": "chat", "description": "..."},
-    {"name": "Achievements", "description": "Operations related to user achievements."}, # <--- НОВЫЙ ТЕГ
-    {"name": "Health", "description": "..."},
-]
+logging.basicConfig(level=logging.INFO)
 
-app = FastAPI(...) # Оставляем как есть
+app = FastAPI(title="AI Friend API")
 
-# --- Подключение Роутеров ---
+# Include routers
 app.include_router(auth_router)
 app.include_router(chat_router)
-# app.include_router(cal_router)
-# app.include_router(audio_router)
+app.include_router(cal_router)
+app.include_router(audio_router)
 app.include_router(health_router)
-app.include_router(achievements_router) # <--- ПОДКЛЮЧАЕМ НОВЫЙ РОУТЕР
-# ---------------------------
+app.include_router(achievements_router)
 
-logging.getLogger(__name__).info(...) # Оставляем как есть
 
-@app.get("/healthz", ...) # Оставляем как есть
+@app.get("/healthz", tags=["Health"])
 async def health_check():
     return {"status": "ok"}

--- a/tests/test_audio_api.py
+++ b/tests/test_audio_api.py
@@ -17,11 +17,16 @@ class FakeTTSClient:
 
 @pytest.fixture(autouse=True)
 def patch_speech(monkeypatch):
-    import google.cloud.speech_v1 as speech
-    import google.cloud.texttospeech_v1 as tts
-    monkeypatch.setattr(speech, 'SpeechClient', lambda: FakeSpeechClient())
-    monkeypatch.setattr(tts, 'TextToSpeechClient', lambda: FakeTTSClient())
+    import types, sys
+    speech = types.ModuleType("speech_v1")
+    tts = types.ModuleType("texttospeech_v1")
+    speech.SpeechClient = lambda: FakeSpeechClient()
+    tts.TextToSpeechClient = lambda: FakeTTSClient()
+    sys.modules['google.cloud.speech_v1'] = speech
+    sys.modules['google.cloud.texttospeech_v1'] = tts
     yield
+    sys.modules.pop('google.cloud.speech_v1', None)
+    sys.modules.pop('google.cloud.texttospeech_v1', None)
 
 def test_chat_audio_endpoint():
     # передаём пустой WAV-заглушку


### PR DESCRIPTION
## Summary
- include audio and calendar routers when creating the FastAPI app
- set `JWT_SECRET_KEY` in test config
- patch Google speech libs in tests
- patch calendar provider reference in tests

## Testing
- `pytest tests/test_audio_api.py tests/test_calendar_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_684485458658832e82845ac310accb6a