### PR TITLE
Cleanup pytest setup

### DIFF
--- a/app/pytest.ini
+++ b/app/pytest.ini
@@ -1,5 +1,0 @@
-# pytest.ini
-[pytest]
-# фигурирует только то, что pytest понимает из коробки
-addopts = -ra -q
-testpaths = tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,10 +1,4 @@
 # pytest.ini
 [pytest]
-# Добавляем корень проекта в PYTHONPATH
+# Добавляем корень проекта в PYTHONPATH (handled in tests/conftest.py)
 python_paths = .
-
-# Переменные окружения для тестов
-env =
-    # чтобы BASE использовал SQLite, а не Postgres
-    ENVIRONMENT = test
-    DATABASE_URL = sqlite:///:memory:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+import os
+import sys
+
+# Ensure project root is on sys.path for 'import app'
+ROOT_DIR = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+# Default environment variables for tests
+os.environ.setdefault("ENVIRONMENT", "test")
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("JWT_SECRET_KEY", "test_secret")
+
+# Load additional fixtures and Celery configuration from the app package
+import app.conftest  # noqa: F401


### PR DESCRIPTION
## Summary
- delete `app/pytest.ini`
- move environment variables into `tests/conftest.py`
- trim unused options from `pytest.ini`

## Testing
- `pytest tests/test_chat_endpoint.py::test_chat --maxfail=1 -vv` *(fails: basicConfig() takes 0 positional arguments but 1 was given)*

------
https://chatgpt.com/codex/tasks/task_e_68448a702078832e8a96a3d798c219b1