### PR TITLE
Fix async tests for llm client

### DIFF
--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,27 +1,25 @@
 import pytest
 from app.core.llm.client import LLMClient, Message
-
-class DummyResp:
-    last = type('X', (), {'text': 'ok'})
+from app.core.llm.providers.stub import StubLLMProvider
 
 @pytest.fixture(autouse=True)
-def patch_genai(monkeypatch):
-    import google.generativeai as genai
-    class DummyChat:
-        @staticmethod
-        def create(**kwargs):
-            return DummyResp()
-    monkeypatch.setattr(genai, 'chat', DummyChat)
-    monkeypatch.setattr(genai, 'configure', lambda api_key=None: None)
+def use_stub_provider(monkeypatch):
+    """Force LLMClient to use the async stub provider."""
+    monkeypatch.setenv("LLM_PROVIDER", "stub")
+    # reset cached provider instance if it was already created
+    import app.core.llm.providers as providers
+    providers._provider_instance = None
     yield
 
-def test_generate():
+@pytest.mark.asyncio
+async def test_generate():
     client = LLMClient()
-    res = client.generate('hi', [Message(role='user', content='hello')])
+    res = await client.generate('hi', [Message(role='user', content='hello')])
     assert res == 'ok'
 
-def test_extract_events_iso():
+@pytest.mark.asyncio
+async def test_extract_events_iso():
     client = LLMClient()
     text = '2025-05-01: Test'
-    events = client.extract_events(text)
+    events = await client.extract_events(text)
     assert isinstance(events, list)


### PR DESCRIPTION
## Summary
- mark llm client tests as asyncio
- await async calls
- switch to stub provider for tests

## Testing
- `PYTHONPATH=. ENVIRONMENT=test DATABASE_URL=sqlite:///:memory: JWT_SECRET_KEY=secret LLM_PROVIDER=stub pytest tests/test_llm_client.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68448a183f14832ebb4c51f4eba2293b