### PR TITLE
Fix FastAPI import and streamline migrations

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 import logging
 
+from fastapi import FastAPI, status
+
 from app.api.v1.auth import router as auth_router
 from app.api.v1.chat import router as chat_router
 from app.api.v1.health import router as health_router
@@ -9,6 +11,7 @@ from app.config import settings
 
 # Configure basic logging
 logging.basicConfig(level=logging.INFO)
+log = logging.getLogger(__name__)
 description = """...""" # Оставляем как есть
 tags_metadata = [ # Добавляем тег для ачивок
     {"name": "Authentication & Testing", "description": "..."},
@@ -20,7 +23,7 @@ tags_metadata = [ # Добавляем тег для ачивок
 app = FastAPI(
     title="AI-Friend API",
     description=description,
-    version="0.2.1",
+    version="0.2.3",
     docs_url="/docs",
     redoc_url="/redoc",
     openapi_tags=tags_metadata,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,9 +32,7 @@ services:
         echo 'Migrate: Waiting for DB...' &&
         until pg_isready -h db -U ai_user -d ai_drug -q; do sleep 1; done &&
         echo 'Migrate: DB ready!' &&
-        echo 'Migrate: Autogenerating (if needed)...' &&
-        alembic -c /app/alembic.ini revision --autogenerate -m 'auto-generated on startup' &&
-        echo 'Migrate: Applying migrations...' &&
+        echo 'Migrate: Applying migrations (upgrade head)...' &&
         alembic -c /app/alembic.ini upgrade head &&
         echo 'Migrate: Finished.'
       "


### PR DESCRIPTION
## Summary
- import `FastAPI` and `status`
- log using configured logger
- bump API version
- avoid autogenerating migrations in compose

## Testing
- `pytest -q` *(fails: OperationalError: no such table: users)*

------
https://chatgpt.com/codex/tasks/task_e_6845b2ca985c832eb6efc0494af053b2