### PR TITLE
Switch calendar endpoint to async list_events

### DIFF
--- a/app/api/v1/calendar.py
+++ b/app/api/v1/calendar.py
@@ -17,7 +17,7 @@ class EventOut(BaseModel):
 
 
 @router.get("/{user_id}", response_model=List[EventOut])
-def get_calendar(user_id: str):
+async def get_calendar(user_id: str):
     prov = get_calendar_provider()
-    events = prov.all_events(user_id)
+    events = await prov.list_events(user_id)
     return [EventOut.model_validate(e) for e in events]

--- a/app/main.py
+++ b/app/main.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 import logging
 
+from fastapi import FastAPI, status
+
 from app.api.v1.auth import router as auth_router
 from app.api.v1.chat import router as chat_router
 from app.api.v1.health import router as health_router
+from app.api.v1.calendar import router as calendar_router
 from app.api.v1.achievements_api import router as achievements_router
 from app.config import settings
 
 # Configure basic logging
 logging.basicConfig(level=logging.INFO)
+log = logging.getLogger(__name__)
 description = """...""" # Оставляем как есть
 tags_metadata = [ # Добавляем тег для ачивок
     {"name": "Authentication & Testing", "description": "..."},
@@ -29,6 +33,7 @@ app = FastAPI(
 app.include_router(auth_router)
 app.include_router(chat_router)
 app.include_router(health_router)
+app.include_router(calendar_router)
 app.include_router(achievements_router)
 
 log.info("\U0001F331 FastAPI application configured. Environment: %s", settings.ENVIRONMENT)

--- a/tests/test_calendar_api.py
+++ b/tests/test_calendar_api.py
@@ -17,13 +17,13 @@ def setup_user_and_events(tmp_path, monkeypatch):
     # Mock CalendarProvider
     from app.core.calendar.base import get_calendar_provider
     class FakeProv:
-        def all_events(self, user_id):
+        async def list_events(self, user_id, *args, **kwargs):
             event = fake_event.model_dump()
             event["start"] = event["start"].isoformat()
             if event["end"] is not None:
                 event["end"] = event["end"].isoformat()
             return [event] if user_id == 'u1' else []
-        def add_event(self, *args, **kwargs):
+        async def add_event(self, *args, **kwargs):
             pass
     import app.api.v1.calendar as calendar_module
     monkeypatch.setattr(calendar_module, 'get_calendar_provider', lambda name=None: FakeProv())


### PR DESCRIPTION
## Summary
- use `list_events` async provider in calendar API
- expose calendar router in `app.main`
- update calendar tests for async provider
- fix FastAPI imports and logging setup

## Testing
- `pytest -k calendar_api -q`
- `pytest -q` *(fails: OperationalError no such table `users`)*

------
https://chatgpt.com/codex/tasks/task_e_6845b950f59c832e83face06e3cca369