### PR TITLE
Add ensure_user wrapper

### DIFF
--- a/app/core/users/service.py
+++ b/app/core/users/service.py
@@ -63,6 +63,10 @@ class UsersService:
             log.debug("Found existing user: %r", user)
         return user
 
+    async def ensure_user(self, user_id: str, name: str | None = None) -> User:
+        """Thin wrapper around :meth:`get_or_create_user` for backwards compatibility."""
+        return await self.get_or_create_user(user_id, name=name)
+
     async def save_message(self, user_id: str, message: Message) -> MessageModel:
         """
         Сохраняет новое сообщение в истории диалога пользователя.

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 import logging
 
+from fastapi import FastAPI, status
+
 from app.api.v1.auth import router as auth_router
 from app.api.v1.chat import router as chat_router
 from app.api.v1.health import router as health_router


### PR DESCRIPTION
## Summary
- implement `ensure_user` method in `UsersService`
- import FastAPI and status in `app/main.py`

## Testing
- `pip install -q -r requirements.txt`
- `pytest tests/test_users_service.py::test_ensure_user_creates_new -q` *(fails: AttributeError: 'AsyncEngine' object has no attribute '_run_ddl_visitor')*

------
https://chatgpt.com/codex/tasks/task_e_6845b95067dc832ebae6bd6b7b429356