### PR TITLE
Implement message count and achievements trigger

### DIFF
--- a/app/db/base.py
+++ b/app/db/base.py
@@ -122,7 +122,8 @@ async def async_session_context() -> AsyncGenerator[AsyncSession, None]:
 async def create_db_and_tables() -> None:
     """Create all tables defined by ``Base``."""
     if settings.ENVIRONMENT == "test":
-        Base.metadata.create_all(bind=engine)
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
     else:
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
@@ -131,7 +132,8 @@ async def create_db_and_tables() -> None:
 async def drop_db_and_tables() -> None:
     """Drop all tables defined by ``Base``."""
     if settings.ENVIRONMENT == "test":
-        Base.metadata.drop_all(bind=engine)
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
     else:
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.drop_all)

--- a/app/main.py
+++ b/app/main.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 import logging
 
+from fastapi import FastAPI, status
 from app.api.v1.auth import router as auth_router
 from app.api.v1.chat import router as chat_router
 from app.api.v1.health import router as health_router
 from app.api.v1.achievements_api import router as achievements_router
+from app.api.v1.audio import router as audio_router
+from app.api.v1.calendar import router as calendar_router
 from app.config import settings
 
 # Configure basic logging
 logging.basicConfig(level=logging.INFO)
+log = logging.getLogger(__name__)
 description = """...""" # Оставляем как есть
 tags_metadata = [ # Добавляем тег для ачивок
     {"name": "Authentication & Testing", "description": "..."},
@@ -30,6 +34,8 @@ app.include_router(auth_router)
 app.include_router(chat_router)
 app.include_router(health_router)
 app.include_router(achievements_router)
+app.include_router(audio_router)
+app.include_router(calendar_router)
 
 log.info("\U0001F331 FastAPI application configured. Environment: %s", settings.ENVIRONMENT)
 

--- a/tests/test_chat_endpoint.py
+++ b/tests/test_chat_endpoint.py
@@ -1,26 +1,55 @@
 import pytest
+import pytest_asyncio
 from fastapi.testclient import TestClient
 from app.main import app
 from app.core.llm.client import LLMClient, Message as LLMMessage, Event
 from app.core.calendar.base import get_calendar_provider
 from app.core.achievements.service import AchievementsService
+from app.db.base import create_db_and_tables, drop_db_and_tables, async_session_context
+from app.core.users.models import User
+from app.core.auth.security import get_current_user, oauth2_scheme
 
 client = TestClient(app)
 
 @ pytest.fixture(autouse=True)
 def patch_dependencies(monkeypatch):
     # Мокаем LLMClient.generate и extract_events
-    monkeypatch.setattr(LLMClient, 'generate', lambda self, prompt, ctx: 'reply text')
-    dummy_event = Event(title='Ev', start=__import__('datetime').datetime(2025,1,1,12,0))
-    monkeypatch.setattr(LLMClient, 'extract_events', lambda self, txt: [dummy_event])
+    async def fake_generate(self, prompt, ctx):
+        return 'reply text'
+    monkeypatch.setattr(LLMClient, 'generate', fake_generate)
+    dummy_event = Event(title='Ev', start=__import__('datetime').datetime(2025,1,1,12,0), end=None)
+    async def fake_extract(self, txt):
+        return [dummy_event]
+    monkeypatch.setattr(LLMClient, 'extract_events', fake_extract)
     # Мокаем CalendarProvider
     class FakeCal:
         def add_event(self, user_id, title, start, end=None): pass
         def list_events(self, *args, **kwargs): return []
-    monkeypatch.setattr(get_calendar_provider.__module__, 'get_calendar_provider', lambda: FakeCal())
+    monkeypatch.setattr('app.core.calendar.get_calendar_provider', lambda: FakeCal())
     # Мокаем выдачу ачивок
-    monkeypatch.setattr(AchievementsService, 'check_and_award', lambda self, uid, evs, rt: [])
+    async def fake_award(self, *a, **kw):
+        return []
+    monkeypatch.setattr(AchievementsService, 'check_and_award', fake_award)
+
+    async def fake_user():
+        async with async_session_context() as session:
+            u = await session.get(User, 'u1')
+            if not u:
+                u = User(id='u1')
+                session.add(u)
+                await session.commit()
+            return u
+
+    app.dependency_overrides[get_current_user] = fake_user
+    app.dependency_overrides[oauth2_scheme] = lambda: "token"
     yield
+    app.dependency_overrides.clear()
+
+@pytest_asyncio.fixture(autouse=True)
+async def setup_db():
+    await create_db_and_tables()
+    yield
+    await drop_db_and_tables()
 
 def test_chat_full_flow():
     payload = {'user_id': 'u1', 'message_text': 'hello'}
@@ -31,3 +60,19 @@ def test_chat_full_flow():
     assert isinstance(data['detected_events'], list)
     # Проверяем, что парсинг и вставка события прошли
     assert data['detected_events'][0]['title'] == 'Ev'
+
+
+def test_first_message_count(monkeypatch):
+    recorded: list[int] = []
+
+    async def fake_check(self, uid=None, message_text=None, user_message_count=0, **_):
+        recorded.append(user_message_count)
+        return []
+
+    monkeypatch.setattr(AchievementsService, 'check_and_award', fake_check)
+
+    client.post('/v1/chat/', json={'user_id': 'u2', 'message_text': 'one'})
+    assert recorded[-1] == 1
+
+    client.post('/v1/chat/', json={'user_id': 'u2', 'message_text': 'two'})
+    assert recorded[-1] == 2

--- a/tests/test_users_service.py
+++ b/tests/test_users_service.py
@@ -1,5 +1,6 @@
 # tests/test_users_service.py (Пример)
 import pytest
+import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession
 
 # Предполагается, что эти импорты работают после настройки PYTHONPATH в pytest.ini
@@ -9,7 +10,7 @@ from app.core.llm.message import Message
 from app.db.base import async_session_context, create_db_and_tables, drop_db_and_tables
 
 # Фикстура для настройки БД перед тестами модуля/сессии
-@pytest.fixture(scope="function", autouse=True) # function scope для изоляции тестов
+@pytest_asyncio.fixture(scope="function", autouse=True)  # function scope
 async def setup_db():
     # Создаем таблицы перед запуском тестов в модуле
     await create_db_and_tables()
@@ -18,7 +19,7 @@ async def setup_db():
     await drop_db_and_tables()
 
 # Асинхронная фикстура для предоставления сессии
-@pytest.fixture
+@pytest_asyncio.fixture
 async def db_session() -> AsyncSession:
     async with async_session_context() as session:
         yield session


### PR DESCRIPTION
## Summary
- support counting user messages in `UsersService`
- integrate new count logic in chat endpoint and extract events
- register audio and calendar routers
- fix async DB helpers and update unit tests
- add tests covering achievement trigger counts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845b951a134832e834202ecd2bec27e