### PR TITLE
Add cloud config fields

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,8 @@
 DATABASE_URL=postgresql://user:pass@localhost:5432/ai_drug
-GOOGLE_PROJECT=your-google-project
-GOOGLE_CALENDAR_CREDENTIALS_JSON_PATH=/path/to/credentials.json
+VERTEX_AI_PROJECT=your-google-project
+VERTEX_AI_LOCATION=us-central1
+GCS_BUCKET_NAME=your-bucket
+GOOGLE_CALENDAR_CREDENTIALS_JSON=/path/to/credentials.json
 GEMINI_API_KEY=YOUR_GEMINI_API_KEY
 LLM_PROVIDER=gemini
 CALENDAR_PROVIDER=google

--- a/app/config.py
+++ b/app/config.py
@@ -31,6 +31,12 @@ class Settings(BaseSettings):
     LLM_PROVIDER: str = Field("stub", env="LLM_PROVIDER")
     GEMINI_API_KEY: Optional[str] = Field(None, env="GEMINI_API_KEY")
     CALENDAR_PROVIDER: str = Field("noop", env="CALENDAR_PROVIDER")
+    VERTEX_AI_PROJECT: Optional[str] = Field(None, env="VERTEX_AI_PROJECT")
+    VERTEX_AI_LOCATION: Optional[str] = Field(None, env="VERTEX_AI_LOCATION")
+    GCS_BUCKET_NAME: Optional[str] = Field(None, env="GCS_BUCKET_NAME")
+    GOOGLE_CALENDAR_CREDENTIALS_JSON: Optional[str] = Field(
+        None, env="GOOGLE_CALENDAR_CREDENTIALS_JSON"
+    )
     # GOOGLE_CLIENT_ID: Optional[str] = Field(None, env="GOOGLE_CLIENT_ID") # Закомментировано для MVP
     # TOKENS_ENCRYPTION_KEY: Optional[str] = Field(None, env="TOKENS_ENCRYPTION_KEY") # Закомментировано для MVP
 


### PR DESCRIPTION
## Summary
- support VertexAI and GCS variables in `Settings`
- update example `.env` with new names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846f4f9bc6c832eb8ae050342b2ae24