### PR TITLE
Add sample Google Cloud env vars

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -8,3 +8,10 @@ SPEECH_LANGUAGE=ru-RU
 TTS_VOICE=ru-RU-Wavenet-D
 CELERY_BROKER_URL=redis://redis:6379/0
 CELERY_RESULT_BACKEND=redis://redis:6379/0
+
+# Example Google Cloud configuration
+# Uncomment and set these if using Vertex AI and Google Cloud Storage
+VERTEX_AI_PROJECT=your-project-id
+VERTEX_AI_LOCATION=us-central1
+GCS_BUCKET_NAME=your-bucket
+GOOGLE_CALENDAR_CREDENTIALS_JSON=/path/to/service-account.json


### PR DESCRIPTION
## Summary
- include example config keys for Vertex AI, GCS and calendar creds in `.env.sample`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846f4fc4a9c832e9ad003b4a6fd15a9