### PR TITLE
Fix pytest fixture decorators

### DIFF
--- a/tests/test_celery_tasks.py
+++ b/tests/test_celery_tasks.py
@@ -3,7 +3,7 @@ from app.workers.tasks import generate_achievement_task, celery_app
 from celery import states
 import asyncio
 
-@ pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True)
 def celery_eager(monkeypatch):
     celery_app.conf.task_always_eager = True
     yield

--- a/tests/test_chat_endpoint.py
+++ b/tests/test_chat_endpoint.py
@@ -11,7 +11,7 @@ from app.core.auth.security import get_current_user, oauth2_scheme
 
 client = TestClient(app)
 
-@ pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True)
 def patch_dependencies(monkeypatch):
     # Мокаем LLMClient.generate и extract_events
     async def fake_generate(self, prompt, ctx):


### PR DESCRIPTION
## Summary
- fix spacing for `pytest.fixture` decorators in test files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846fc1ee4f0832e81d4c8ce3fe4b6a4