### PR TITLE
Fix gemini provider call and update env sample

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -13,7 +13,3 @@ CELERY_RESULT_BACKEND=redis://redis:6379/0
 
 # Example Google Cloud configuration
 # Uncomment and set these if using Vertex AI and Google Cloud Storage
-VERTEX_AI_PROJECT=your-project-id
-VERTEX_AI_LOCATION=us-central1
-GCS_BUCKET_NAME=your-bucket-name
-GOOGLE_CALENDAR_CREDENTIALS_JSON=/app/credentials/sa.json


### PR DESCRIPTION
## Summary
- update Gemini provider to avoid `system_instruction` parameter
- clarify log message and drop unused variable
- clean up duplicated vars in `.env.sample`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846f08dd96c832eba37236186b9fee7